### PR TITLE
docs: use pr-review skill for PR reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,7 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs Jest tests on PRs to
 - **GET /pdf/:uuid**: Retrieve PDF
 - **HEAD /pdf/:uuid**: Check if PDF exists
 - **DELETE /pdf/:uuid**: Delete PDF from S3
+
+## Reviewing PRs
+
+Whenever I ask to review a PR (pull request), use the `pr-review` skill.


### PR DESCRIPTION
Records the project convention that PR review requests should be handled via the `pr-review` skill. Documentation-only change to `CLAUDE.md`.