### PR TITLE
chore: exclude local .claude settings from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,6 @@ yarn.lock
 pnpm-lock.yaml
 .next
 .nuxt
+
+# Local, untracked tool settings
+.claude


### PR DESCRIPTION
`prettier --check .` scanned the untracked `.claude/settings.local.json`, failing `npm run check` and the pre-push hook on a local-only file. Add `.claude` to `.prettierignore`.